### PR TITLE
Coerce non-string/unicode elements of the templating transaction to strin

### DIFF
--- a/ezio/Ezio.h
+++ b/ezio/Ezio.h
@@ -69,9 +69,9 @@ class PySmartPointer {
 };
 
 /* Status codes that can be returned by the coercion/filtering code. */
-#define COERCED_TO_STR 0
-#define COERCED_TO_UNICODE 1
-#define COERCE_FAILED 2
+static const int COERCED_TO_STR = 0;
+static const int COERCED_TO_UNICODE = 1;
+static const int COERCE_FAILED = 2;
 
 /** A callback type; a filter must take in a PyObject * and return a new reference
   Implement this interface to transform the elements of the templating transaction
@@ -101,7 +101,7 @@ PyObject *default_unicode_filter(PyObject *item, void *closure_data) {
   and modify `status` to reflect the success or failure of the coercions.
 
   This implementation (and others here) is unsafe in general because
-  they re-enter the interpreter without re-checking list bounds.
+  it re-enters the interpreter without re-checking list bounds.
   This is OK in this case because only internal C++ code has a reference
   to `transaction`, so the list bounds cannot vary.
 

--- a/ezio/Ezio.h
+++ b/ezio/Ezio.h
@@ -57,7 +57,7 @@ class PySmartPointer {
     public:
         // this value can be NULL and always requires a NULL test before use
         PyObject *referent;
-        PySmartPointer() { referent = NULL; }
+        PySmartPointer() : referent(NULL) {}
         PySmartPointer(PyObject *referent) : referent(referent) {}
         ~PySmartPointer() { Py_XDECREF(referent); }
         // we could overload the assignment operator here, but we don't really need the magic:
@@ -67,3 +67,183 @@ class PySmartPointer {
             referent = new_referent;
         }
 };
+
+/* Status codes that can be returned by the coercion/filtering code. */
+#define COERCED_TO_STR 0
+#define COERCED_TO_UNICODE 1
+#define COERCE_FAILED 2
+
+/** A callback type; a filter must take in a PyObject * and return a new reference
+  Implement this interface to transform the elements of the templating transaction
+  at "join time".
+  */
+typedef PyObject* (*Ezio_Filter)(PyObject *operand, void *closure_data);
+
+/** Ezio_Filter that transforms objects into Unicodes. */
+PyObject *default_unicode_filter(PyObject *item, void *closure_data) {
+    if (PyUnicode_Check(item)) {
+        Py_INCREF(item);
+        return item;
+    }
+
+    // promote a common case in PyObject_Unicode, the decoding of strings:
+    if (PyString_Check(item)) {
+        return PyUnicode_Decode(PyString_AS_STRING(item),
+                PyString_GET_SIZE(item), NULL, NULL);
+    } else {
+        // this is the `unicode` built-in:
+        return PyObject_Unicode(item);
+    }
+}
+
+/** Apply an Ezio_Filter that returns unicodes to a list `transaction`;
+  return the total length of the unicodes (for buffer pre-allocation),
+  and modify `status` to reflect the success or failure of the coercions.
+
+  This implementation (and others here) is unsafe in general because
+  they re-enter the interpreter without re-checking list bounds.
+  This is OK in this case because only internal C++ code has a reference
+  to `transaction`, so the list bounds cannot vary.
+
+  In the future, this is the place where we'll implement HTML escaping,
+  by passing an Ezio_Filter that does escaping intelligently.
+  */
+Py_ssize_t apply_unicode_filter(PyObject *transaction, int *status,
+                                Ezio_Filter filter, void *closure_data) {
+    if (!(transaction && PyList_CheckExact(transaction))) {
+        *status = COERCE_FAILED;
+        return 0;
+    }
+
+    Py_ssize_t size = PyList_GET_SIZE(transaction);
+    Py_ssize_t seqlen = 0;
+    Py_ssize_t i;
+    for (i = 0; i < size; i++) {
+        PyObject *item = PyList_GET_ITEM(transaction, i);
+        PyObject *filtered_item = filter(item, closure_data);
+        if (filtered_item == NULL) {
+            *status = COERCE_FAILED;
+            return 0;
+        }
+        // replace the list entry with the filtered_item:
+        Py_DECREF(item);
+        PyList_SET_ITEM(transaction, i, filtered_item);
+        seqlen += PyUnicode_GET_SIZE(filtered_item);
+    }
+
+    *status = COERCED_TO_UNICODE;
+    return seqlen;
+}
+
+
+/** Attempt to coerce all elements of `transaction` to string,
+  unless one of them is a unicode, in which case coerce everything
+  to unicode. This is more or less what standard str.join() does
+  (except, of course, that it performs coercion and modifies `transaction`
+  in place with the results of the coercions).
+  */
+Py_ssize_t coerce_all(PyObject *transaction, int *status) {
+    if (!(transaction && PyList_CheckExact(transaction))) {
+        *status = COERCE_FAILED;
+        return 0;
+    }
+
+    Py_ssize_t size = PyList_GET_SIZE(transaction);
+    Py_ssize_t seqlen = 0;
+    Py_ssize_t i;
+    for (i = 0; i < size; i++) {
+        PyObject *item = PyList_GET_ITEM(transaction, i);
+        if (!PyString_Check(item)) {
+            if (PyUnicode_Check(item)) {
+                // coerce all transaction elements to unicode using the default unicode filter
+                return apply_unicode_filter(transaction, status, default_unicode_filter, NULL);
+            } else {
+                PyObject *coerced_item = PyObject_Str(item);
+                if (coerced_item != NULL) {
+                    // discard the ref to the old value, steal one to the new one
+                    Py_DECREF(item);
+                    PyList_SET_ITEM(transaction, i, coerced_item);
+                    item = coerced_item;
+                } else {
+                    *status = COERCE_FAILED;
+                    return 0;
+                }
+            }
+        }
+        seqlen += PyString_GET_SIZE(item);
+    }
+
+    *status = COERCED_TO_STR;
+    return seqlen;
+}
+
+/** Assuming `transaction` contains only strings and their total length is
+  `total_length`, concatenate them all and return a new reference to the
+  resulting string.
+  */
+PyObject *concatenate_strings(PyObject *transaction, Py_ssize_t total_length) {
+    PyObject *res = PyString_FromStringAndSize((char*)NULL, total_length);
+    if (res == NULL) {
+        return NULL;
+    }
+
+    char *buf = PyString_AS_STRING(res);
+    Py_ssize_t size = PyList_GET_SIZE(transaction);
+    Py_ssize_t i;
+    for (i = 0; i < size; i++) {
+        PyObject *item = PyList_GET_ITEM(transaction, i);
+        size_t n = PyString_GET_SIZE(item);
+        Py_MEMCPY(buf, PyString_AS_STRING(item), n);
+        buf += n;
+    }
+
+    return res;
+}
+
+/** Like concatenate_strings, but for unicodes. Mostly copied and pasted from the above.
+  */
+PyObject *concatenate_unicodes(PyObject *transaction, Py_ssize_t total_length) {
+    PyObject *res = PyUnicode_FromUnicode(NULL, total_length);
+    if (res == NULL) {
+        return NULL;
+    }
+
+    Py_UNICODE *buf = PyUnicode_AS_UNICODE(res);
+    Py_ssize_t size = PyList_GET_SIZE(transaction);
+    Py_ssize_t i;
+    for (i = 0; i < size; i++) {
+        PyObject *item = PyList_GET_ITEM(transaction, i);
+        Py_ssize_t n = PyUnicode_GET_SIZE(item);
+        Py_UNICODE_COPY(buf, PyUnicode_AS_UNICODE(item), n);
+        buf += n;
+    }
+
+    return res;
+}
+
+/** Combines coerce_all, concatenate_strings, and concatenate_unicodes
+  to make an analogue of str.join() that coerces non-strings to strings
+  (and, like str.join(), coerces everything to unicode if unicode is encountered).
+  */
+PyObject *ezio_concatenate(PyObject *transaction) {
+    if (!(transaction && PyList_CheckExact(transaction))) {
+        return NULL;
+    }
+
+    int status;
+    Py_ssize_t total_length = coerce_all(transaction, &status);
+    if (status == COERCE_FAILED) {
+        // propagates exceptions raised during coercion:
+        return NULL;
+    }
+
+    if (status == COERCED_TO_STR) {
+        return concatenate_strings(transaction, total_length);
+    } else if (status == COERCED_TO_UNICODE) {
+        return concatenate_unicodes(transaction, total_length);
+    } else {
+        // internal error
+        PyErr_SetString(PyExc_SystemError, "Invalid coercion status.");
+        return NULL;
+    }
+}

--- a/ezio/Ezio.h
+++ b/ezio/Ezio.h
@@ -182,7 +182,7 @@ Py_ssize_t coerce_all(PyObject *transaction, int *status) {
   resulting string.
   */
 PyObject *concatenate_strings(PyObject *transaction, Py_ssize_t total_length) {
-    PyObject *res = PyString_FromStringAndSize((char*)NULL, total_length);
+    PyObject *res = PyString_FromStringAndSize(NULL, total_length);
     if (res == NULL) {
         return NULL;
     }

--- a/ezio/compiler.py
+++ b/ezio/compiler.py
@@ -520,7 +520,7 @@ def generate_hook(function_name, class_name, public=True):
                  to the caller
     """
     buf = LineBufferMixin()
-    buf.add_line('static PyObject *%s(PyObject *self, PyObject *args) {' % function_name)
+    buf.add_line('static PyObject *%s(PyObject *self, PyObject *args) {' % (function_name,))
     buf.indent += 1
 
     buf.add_line('PyObject *display, *transaction;')

--- a/ezio/compiler.py
+++ b/ezio/compiler.py
@@ -21,6 +21,9 @@ EXPRESSIONS_ARRAY_NAME = 'expressions'
 EXPRESSIONS_EXCEPTION_HANDLER = 'HANDLE_EXCEPTIONS_EXPRESSIONS'
 MAIN_FUNCTION_NAME = "respond"
 TERMINAL_EXCEPTION_HANDLER = "REPORT_EXCEPTION_TO_PYTHON"
+# put all the template classes in this namespace,
+# so they don't conflict with C names from Python.h:
+CPP_NAMESPACE = "ezio_templates"
 
 RESERVED_WORDS = set([DISPLAY_NAME, TRANSACTION_NAME, LITERALS_ARRAY_NAME, IMPORT_ARRAY_NAME, MAIN_FUNCTION_NAME])
 
@@ -486,8 +489,8 @@ def generate_final_segment(module_name, function_names):
     buf.add_line("static PyMethodDef k_module_methods[] = {")
     buf.indent += 1
     for function_name in function_names:
-        buf.add_line('{"%s", (PyCFunction)%s, METH_VARARGS, "Perform templating for %s"},' %
-            (function_name, function_name, function_name))
+        buf.add_line('{"%s", (PyCFunction)%s::%s, METH_VARARGS, "Perform templating for %s"},' %
+            (function_name, CPP_NAMESPACE, function_name, function_name))
     buf.add_line("{NULL, NULL, 0, NULL}")
     buf.indent -= 1
     buf.add_line("};")
@@ -507,29 +510,48 @@ def generate_final_segment(module_name, function_names):
     return buf
 
 
-def generate_hook(function_name, class_name):
+def generate_hook(function_name, class_name, public=True):
     """Generate the static "hook" function that unpacks the Python arguments,
     dispatches to the C++ code, then returns the result to Python.
+
+    Args:
+        public - if False, generate the "old-style" hook that takes in a
+                 transaction list as second argument, then defers string join
+                 to the caller
     """
     buf = LineBufferMixin()
-
     buf.add_line('static PyObject *%s(PyObject *self, PyObject *args) {' % function_name)
     buf.indent += 1
-    buf.add_line('PyObject *%s, *%s;' % (DISPLAY_NAME, TRANSACTION_NAME))
+
+    buf.add_line('PyObject *display, *transaction;')
     # TODO type-check list and dict here
-    buf.add_line('if (!PyArg_ParseTuple(args, "OO", &%s, &%s)) {'
-        % (DISPLAY_NAME, TRANSACTION_NAME))
-    buf.indent += 1
-    buf.add_line('return NULL;')
-    buf.indent -= 1
-    buf.add_line('}')
-    buf.add_line('%s template_obj(%s, %s);' % (class_name, DISPLAY_NAME, TRANSACTION_NAME))
+    if public:
+        unpack = '"O", &display'
+    else:
+        unpack = '"OO", &display, &transaction'
+    buf.add_line('if (!PyArg_ParseTuple(args, %s)) { return NULL; }' % (unpack,))
+    if public:
+        # create a new list for the transaction
+        buf.add_line('if (!(transaction = PyList_New(0))) { return NULL; }')
+
+    buf.add_line('%s::%s template_obj(display, transaction);' % (CPP_NAMESPACE, class_name,))
     buf.add_line('PyObject *status = template_obj.%s();' % (MAIN_FUNCTION_NAME,))
     buf.add_line('if (status) {')
-    buf.indent += 1
-    buf.add_line('Py_INCREF(status); return status;')
-    buf.indent -= 1
-    buf.add_line('} else { return NULL; }')
+    with buf.increased_indent():
+        if public:
+            buf.add_line('PyObject *result = ezio_concatenate(transaction);')
+            buf.add_line('Py_DECREF(transaction);')
+            # this wil propagate exceptions during concatenation:
+            buf.add_line('return result;')
+        else:
+            # just return the status value
+            buf.add_line('Py_INCREF(status); return status;')
+    buf.add_line('}')
+    # exit path for when templating encountered an exception
+    if public:
+        buf.add_line('Py_DECREF(transaction);')
+    buf.add_line('return NULL;')
+
     buf.indent -= 1
     buf.add_line('}')
 
@@ -548,8 +570,10 @@ def generate_c_file(module_name, literal_registry, path_registry, import_registr
     cpp_file.add_fixup(import_registry)
     cpp_file.add_fixup(expression_registry)
 
-    # concatenate all class definitions and their method definitions
+    # concatenate all class definitions and their method definitions,
+    # enclosing them in a C++ namespace:
     hook_names = []
+    cpp_file.add_line("namespace %s {" % (CPP_NAMESPACE,))
     for compiled_class in compiled_classes:
         # add the class definition:
         cpp_file.add_fixup(compiled_class.class_definition)
@@ -558,8 +582,9 @@ def generate_c_file(module_name, literal_registry, path_registry, import_registr
 
         class_name = compiled_class.class_definition.class_name
         hook_name = "%s_%s" % (class_name, MAIN_FUNCTION_NAME)
-        cpp_file.add_fixup(generate_hook(hook_name, class_name))
+        cpp_file.add_fixup(generate_hook(hook_name, class_name, public=True))
         hook_names.append(hook_name)
+    cpp_file.add_line("}")
 
     cpp_file.add_fixup(generate_final_segment(module_name, hook_names))
 

--- a/tools/runtest
+++ b/tools/runtest
@@ -11,14 +11,12 @@ subprocess.check_call(['bin/ezio', 'tools/templates/%s.tmpl' % testname])
 template_module = __import__('tools.templates.%s' % testname, globals(), locals(), [testname])
 bootstrap_module = __import__('tools.tests.%s' % testname, globals(), locals(), [testname])
 
-transaction = []
 display = bootstrap_module.display
 responder_name = "%s_respond" % testname
 responder = getattr(template_module, responder_name)
 
 start_time = time.time()
-responder(display, transaction)
-result = "".join(transaction)
+result = responder(display)
 elapsed = time.time() - start_time
 
 print result

--- a/tools/templates/coercion.tmpl
+++ b/tools/templates/coercion.tmpl
@@ -6,3 +6,5 @@ third
 $third
 fourth
 $fourth
+fifth
+$fifth

--- a/tools/templates/coercion.tmpl
+++ b/tools/templates/coercion.tmpl
@@ -1,0 +1,8 @@
+first
+$first
+second
+$second
+third
+$third
+fourth
+$fourth

--- a/tools/tests/bigtable_original.py
+++ b/tools/tests/bigtable_original.py
@@ -1,0 +1,25 @@
+"""
+This is the original benchmark from Spitfire, i.e., with numbers as keys
+that must be converted to string at template time.
+"""
+
+import testify
+
+from tools.tests.test_case import EZIOTestCase
+
+table = [dict(a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8,i=9,j=10)
+          for x in range(1000)]
+
+display = {'table': table}
+
+class TestCase(EZIOTestCase):
+    target_template = 'bigtable'
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return [display, display['table'], display.keys()[0], display.values()[0]]
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/coercion.py
+++ b/tools/tests/coercion.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+
+import testify
+from testify.assertions import assert_equal
+
+from tools.tests.test_case import EZIOTestCase
+
+class MyStringable(object):
+    def __str__(self):
+        return 'ohai'
+
+display = {
+        'first': 1,
+        'second': 2.0,
+        'third': 'asdf',
+        'fourth': MyStringable(),
+}
+
+class SimpleTestCase(EZIOTestCase):
+
+    target_template = 'coercion'
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return display.values()
+
+    def test(self):
+        super(SimpleTestCase, self).test()
+        assert_equal(
+            self.result.split(),
+            ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohai']
+        )
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/coercion.py
+++ b/tools/tests/coercion.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import testify
 from testify.assertions import assert_equal
@@ -14,11 +15,17 @@ display = {
         'second': 2.0,
         'third': 'asdf',
         'fourth': MyStringable(),
+        # this is a UTF-8 encoding of a unicode string, but here Python interprets it
+        # as a byte sequence (i.e., an instance of the 'str' class), since it's a literal
+        # without a preceding u
+        'fifth': 'hommage à jack',
 }
 
 class SimpleTestCase(EZIOTestCase):
 
     target_template = 'coercion'
+
+    expected_result_type = str
 
     def get_display(self):
         return display
@@ -29,8 +36,10 @@ class SimpleTestCase(EZIOTestCase):
     def test(self):
         super(SimpleTestCase, self).test()
         assert_equal(
-            self.result.split(),
-            ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohai']
+            self.result.strip().split('\n'),
+            ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohai',
+             'fifth', 'hommage à jack'
+            ]
         )
 
 if __name__ == '__main__':

--- a/tools/tests/test_case.py
+++ b/tools/tests/test_case.py
@@ -32,6 +32,8 @@ class EZIOTestCase(testify.TestCase):
 
     num_stress_test_iterations = 1
 
+    expected_result_type = str
+
     @property
     def template_name(self):
         if self.target_template is not None:
@@ -79,16 +81,16 @@ class EZIOTestCase(testify.TestCase):
 
     def run_templating(self, quiet=False):
         """Run the display dict against self.responder, get the output, measure the elapsed time."""
-        transaction = []
         display = self.get_display()
         responder = self.responder
 
         self.result = result = None
         start_time = time.time()
-        responder(display, transaction)
-        result = "".join(transaction)
+        result = responder(display)
         self.elapsed_time = time.time() - start_time
         self.result = result
+
+        assert_equal(type(result), self.expected_result_type)
 
         if self.verbose and not quiet:
             print self.result

--- a/tools/tests/unicode_coercion.py
+++ b/tools/tests/unicode_coercion.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+import testify
+from testify.assertions import assert_equal
+
+from tools.tests.test_case import EZIOTestCase
+
+class MyStringable(object):
+    def __str__(self):
+        return 'ohai'
+
+    def __unicode__(self):
+        return 'ohaiunicode'
+
+display = {
+        'first': 1,
+        'second': 2.0,
+        'third': u'asdf',
+        'fourth': MyStringable(),
+}
+
+class SimpleTestCase(EZIOTestCase):
+
+    target_template = 'coercion'
+
+    # $third is a unicode (u'asdf'), which forces coercion of everything to unicode
+    expected_result_type = unicode
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return display.values()
+
+    def test(self):
+        super(SimpleTestCase, self).test()
+        assert_equal(
+            self.result.split(),
+            ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohaiunicode']
+        )
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/unicode_coercion.py
+++ b/tools/tests/unicode_coercion.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import testify
 from testify.assertions import assert_equal
@@ -17,6 +18,8 @@ display = {
         'second': 2.0,
         'third': u'asdf',
         'fourth': MyStringable(),
+        # this is a true unicode object that happens to also contain a non-ASCII character:
+        'fifth': u"hommage à jack",
 }
 
 class SimpleTestCase(EZIOTestCase):
@@ -34,9 +37,13 @@ class SimpleTestCase(EZIOTestCase):
 
     def test(self):
         super(SimpleTestCase, self).test()
+        # note that 'asdf' == u'asdf', so we don't need to explicitly prefix the
+        # literals here with u:
         assert_equal(
-            self.result.split(),
-            ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohaiunicode']
+            self.result.strip().split('\n'),
+            ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohaiunicode',
+             'fifth', u'hommage \xe0 jack'
+            ]
         )
 
 if __name__ == '__main__':

--- a/tools/tests/unicode_coercion.py
+++ b/tools/tests/unicode_coercion.py
@@ -10,7 +10,7 @@ class MyStringable(object):
         return 'ohai'
 
     def __unicode__(self):
-        return 'ohaiunicode'
+        return u'ohaiunicode'
 
 display = {
         'first': 1,


### PR DESCRIPTION
Coerce non-string/unicode elements of the templating transaction to string/unicode before joining
(so, e.g., support ints and floats directly without requiring preconversion to string).

Implement the Python 2.x str.join() behavior where if any element of the sequence is a unicode,
everything gets coerced to unicode and the final result is a unicode, otherwise everything
remains a string.
