### PR TITLE
Support one-lining of conditional statements; fix escaping rules

### DIFF
--- a/ezio/tmpl2py.py
+++ b/ezio/tmpl2py.py
@@ -146,12 +146,6 @@ DIRECTIVE_REGEX = re.compile('^\s*#')
 # (the \ and the $ are regex metacharacters and must be escaped here)
 METACHARACTER_REGEX = re.compile(r'#|\\|\$')
 
-def stringify_literal(string):
-    """Turn a chunk of literal text into a Python string literal, unescaping
-    dollar signs and making sure that it fits on one line.
-    """
-    return repr(string.replace('$$', '$'))
-
 # a group of an odd number of dollar signs
 UNESCAPED_DOLLAR = re.compile( r'''
         (?<!{dollar})           # not preceded by a dollar
@@ -213,13 +207,13 @@ class LiteralTextStrategy(object):
                         continue
                 elif metacharacter == "#":
                     # unescaped # --- break out into directive mode
-                    py_out.commit_line(stringify_literal(consumed) + '\n')
+                    py_out.commit_line(repr(consumed) + '\n')
                     break
                 elif metacharacter == "$":
                     if subsequent_char.isalpha() or subsequent_char in ('_', '(', '[', '{'):
                         # this is the start of a valid Python identifer,
                         # or a Cheetah placeholder block. break out:
-                        py_out.commit_line(stringify_literal(consumed) + '\n')
+                        py_out.commit_line(repr(consumed) + '\n')
                         break
                     else:
                         # this is just a $, e.g., $100.00
@@ -243,7 +237,7 @@ class LiteralTextStrategy(object):
                 # When a directive is the last line in the file, this will
                 # terminate us without adding a spurious newline.
                 if consumed != '':
-                    py_out.commit_line(stringify_literal(consumed) + '\n')
+                    py_out.commit_line(repr(consumed) + '\n')
                 break
 
             # else continue (implicitly)

--- a/ezio/tmpl2py.py
+++ b/ezio/tmpl2py.py
@@ -33,19 +33,6 @@
 
     The main entry points to this module are ``tmpl2py()`` and
     ``tmpl2PyOut()``.
-
-    Here's one way to understand the Cheetah template syntax. A Cheetah compiler
-    is a state machine; it's either in Cheetah mode (handling bare literal text)
-    or in Python/"placeholder" mode (handling Python code). The problem is that
-    the transition rule between these states isn't regular, but context-free, e.g.,
-
-    i'm literal text $but("i'm", ("not", "instead", ("I'm Python!",))) see?
-
-    we must in some sense count the closing parentheses before we can re-enter
-    Cheetah mode. This is why the compiler doesn't separate naturally into "lexer"
-    and "parser" layers; the "natural" breakdown of lexical units for Python is
-    incompatible with Cheetah and vice versa, and we can't transition between the
-    two systems within the lexer itself.
 """
 
 import ast

--- a/ezio/tmpl2py.py
+++ b/ezio/tmpl2py.py
@@ -33,6 +33,19 @@
 
     The main entry points to this module are ``tmpl2py()`` and
     ``tmpl2PyOut()``.
+
+    Here's one way to understand the Cheetah template syntax. A Cheetah compiler
+    is a state machine; it's either in Cheetah mode (handling bare literal text)
+    or in Python/"placeholder" mode (handling Python code). The problem is that
+    the transition rule between these states isn't regular, but context-free, e.g.,
+
+    i'm literal text $but("i'm", ("not", "instead", ("I'm Python!",))) see?
+
+    we must in some sense count the closing parentheses before we can re-enter
+    Cheetah mode. This is why the compiler doesn't separate naturally into "lexer"
+    and "parser" layers; the "natural" breakdown of lexical units for Python is
+    incompatible with Cheetah and vice versa, and we can't transition between the
+    two systems within the lexer itself.
 """
 
 import ast
@@ -129,6 +142,9 @@ def idempotent_de_dollar(string):
 
 # a ``#`` is the first non-whitespace character
 DIRECTIVE_REGEX = re.compile('^\s*#')
+# the Cheetah metacharacters: $, #, and \
+# (the \ and the $ are regex metacharacters and must be escaped here)
+METACHARACTER_REGEX = re.compile(r'#|\\|\$')
 
 def stringify_literal(string):
     """Turn a chunk of literal text into a Python string literal, unescaping
@@ -160,21 +176,59 @@ class LiteralTextStrategy(object):
     def consume(self, py_out, driver):
         consumed = ''
 
-        while True: # terminate after the end of literal text
+        # loop until we encounter the end of of literal text
+        while True:
 
-            # These two ifs are termination conditions (note the breaks)
+            # search for any of our special characters
+            metacharacter_match = METACHARACTER_REGEX.search(driver.head)
 
-            if DIRECTIVE_REGEX.match(driver.head): # the last line
-                py_out.commit_line(stringify_literal(consumed) + '\n')
-                break
+            # read "continue" as "we're still in literal text" and "break" as "we're now outside it"
+            if metacharacter_match:
+                metacharacter = metacharacter_match.group(0)
+                start_pos = metacharacter_match.start(0)
+                before_metacharacter = driver.head[:start_pos]
+                # TODO if a line begins with whitespace and a #, should we suppress the whitespace?
+                consumed += before_metacharacter
 
-            match = UNESCAPED_DOLLAR.search(driver.head)
-            if match:
-                before_dollar = driver.head[:match.end(1)]
-                consumed += before_dollar
-                driver.advance_past(before_dollar)
-                py_out.commit_line(stringify_literal(consumed) + '\n')
-                break
+                # read the character following the metacharacter
+                subsequent_pos = start_pos + 1
+                subsequent_char = driver.head[subsequent_pos] if subsequent_pos < len(driver.head) \
+                        else None
+
+                # OK, skip over the consumed text; leave the metacharacter for now
+                driver.advance_past(before_metacharacter)
+
+                if metacharacter == "\\":
+                    if subsequent_char in ("\\", "#", "$"):
+                        # subsequent char is an escaped metacharacter, consume and skip it
+                        # i.e., \# means #, and \$ means $
+                        driver.advance_past(driver.head[:2])
+                        consumed += subsequent_char
+                        continue
+                    else:
+                        # next char is not a metacharacter; write the backslash
+                        # i.e., \a means \a, and \<newline> means \<newline>
+                        driver.advance_past(driver.head[:1])
+                        consumed += "\\"
+                        continue
+                elif metacharacter == "#":
+                    # unescaped # --- break out into directive mode
+                    py_out.commit_line(stringify_literal(consumed) + '\n')
+                    break
+                elif metacharacter == "$":
+                    if subsequent_char.isalpha() or subsequent_char in ('_', '(', '[', '{'):
+                        # this is the start of a valid Python identifer,
+                        # or a Cheetah placeholder block. break out:
+                        py_out.commit_line(stringify_literal(consumed) + '\n')
+                        break
+                    else:
+                        # this is just a $, e.g., $100.00
+                        driver.advance_past(driver.head[:1])
+                        consumed += "$"
+                        continue
+                else:
+                    # regex matched a non-metacharacter; this should never happen
+                    raise ValueError(metacharacter)
 
             # Consume the current line.
             # Only one line is ever in driver.head during this loop.
@@ -221,10 +275,11 @@ def mk_mungepair(prefix, suffix, compound=False):
 
     return MungePair(munger, unmunger)
 
-# Cut out the key to use for getting the munger/unmunger pair.
+# Cut out the key to use for getting the munger/unmunger pair;
+# we're looking for either an @ or the alphabetical characters of a Python keyword.
 # This pattern has the important property of always matching, even if it is
 # the empty string, so we can safely .group(0) off of a .match() call.
-MUNGE_KEYGETTER = re.compile('^(@|\S*)')
+MUNGE_KEYGETTER = re.compile('^(@|[A-Za-z]*)')
 
 _munge_pairs = (
 
@@ -288,7 +343,7 @@ class LinewisePurePythonStrategy(object):
         if kwd in ('else', 'elif', 'except', 'finally'):
             py_out.dedent()
 
-        for prefix in driver.increasing_prefixes('\n'):
+        for prefix in driver.increasing_prefixes('#\n'):
             munged = munge_pair.munge(prefix)
             try:
                 ast.parse(idempotent_de_dollar(munged))
@@ -309,8 +364,12 @@ class EndSuiteStrategy(object):
         return string.startswith('end')
 
     def consume(self, py_out, driver):
-        # advance_past() everything, because we only have one line
-        driver.advance_past(driver.head)
+        # read up to a # or a \n, then stop
+        for prefix in driver.increasing_prefixes('#\n'):
+            driver.advance_past(prefix)
+            py_out.dedent()
+            return
+        # EOF without a newline:
         py_out.dedent()
 
 class ExtendsStrategy(object):
@@ -744,16 +803,18 @@ class EzioTemplateDriver(object):
 
         self.head += line
 
-    def increasing_prefixes(self, char):
-        """Return increasing prefixes ending with char.
+    def increasing_prefixes(self, chars):
+        """Return increasing prefixes ending with a char in `chars`.
 
         This is the secret sauce for plucking out syntactically valid Python
         from the template.
         """
 
         beginpos = 0
+        # make a regex matching any character in chars
         # don't worry, re.compile caches compiled regexes
-        regex = re.compile(re.escape(char))
+        regex_str = '|'.join(re.escape(char) for char in chars)
+        regex = re.compile(regex_str)
 
         while beginpos != len(self.head): # have more to process
 

--- a/ezio/tmpl2py.py
+++ b/ezio/tmpl2py.py
@@ -199,7 +199,7 @@ class LiteralTextStrategy(object):
                 driver.advance_past(before_metacharacter)
 
                 if metacharacter == "\\":
-                    if subsequent_char in ("\\", "#", "$"):
+                    if subsequent_char in ("#", "$"):
                         # subsequent char is an escaped metacharacter, consume and skip it
                         # i.e., \# means #, and \$ means $
                         driver.advance_past(driver.head[:2])

--- a/tools/templates/if_statements_basic.tmpl
+++ b/tools/templates/if_statements_basic.tmpl
@@ -57,3 +57,6 @@ NO
 #else
 OK
 #end if
+
+## repeat the above test, but on one line:
+#if not $true_obj1#NO#else#OK#end if#

--- a/tools/templates/oneline_conditionals.tmpl
+++ b/tools/templates/oneline_conditionals.tmpl
@@ -1,0 +1,7 @@
+## Test one-lineing of conditionals
+I'm#if not $true_obj# NO#else# OK#end if#
+I'm #if $false_obj#NO#else#OK#end if#
+The alphabet begins with#for letter in sequence# $letter#end for#
+#if $true_obj#$interpolant#end if# is interpolated
+I'm #if $false_obj#NO#else#OK#end if# still
+Success!

--- a/tools/templates/stress_test.tmpl
+++ b/tools/templates/stress_test.tmpl
@@ -20,9 +20,14 @@
 #def ezio()
     startit
     $myblock($asdf)
-    <td>stuff</td><td>$$bag.five</td>
+    <td>stuff</td><td>\$bag.five</td>
     $myfunc(asdf, f)
 #end def
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"  "http://www.w3.org/TR/html4/loose.dtd">
 $ezio()
+
+\#def notadef
+this isn't a \$function
+one backslash looks like \ or \\ and two look like \\\\!
+\#end def

--- a/tools/templates/stress_test.tmpl
+++ b/tools/templates/stress_test.tmpl
@@ -29,5 +29,5 @@ $ezio()
 
 \#def notadef
 this isn't a \$function
-one backslash looks like \ or \\ and two look like \\\\!
+one backslash looks like \ and two look like \\!
 \#end def

--- a/tools/templates/stress_test.tmpl
+++ b/tools/templates/stress_test.tmpl
@@ -30,4 +30,5 @@ $ezio()
 \#def notadef
 this isn't a \$function
 one backslash looks like \ and two look like \\!
+Two dollar signs make a $$
 \#end def

--- a/tools/tests/if_statements_basic.py
+++ b/tools/tests/if_statements_basic.py
@@ -33,7 +33,7 @@ class TestCase(EZIOTestCase):
     def test(self):
         super(TestCase, self).test()
 
-        assert_equal(self.result.split(), ['OK'] * 10)
+        assert_equal(self.result.split(), ['OK'] * 11)
 
 if __name__ == '__main__':
     testify.run()

--- a/tools/tests/oneline_conditionals.py
+++ b/tools/tests/oneline_conditionals.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import sys
+
+import testify
+from testify.assertions import assert_equal
+
+from tools.tests.test_case import EZIOTestCase
+
+def f():
+    return True
+
+display = {
+    'true_obj': True,
+    'false_obj': False,
+    'sequence': ['a', 'b', 'c', 'd', 'e'],
+    'interpolant': 'The interpolant',
+}
+
+class TestCase(EZIOTestCase):
+
+    target_template = 'oneline_conditionals'
+    num_stress_test_iterations = 100
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return sorted(display.itervalues())
+
+    def test(self):
+        super(TestCase, self).test()
+
+        lines = [line for line in self.result.split('\n') if line]
+        assert_equal(lines, [
+            "I'm OK",
+            "I'm OK",
+            "The alphabet begins with a b c d e",
+            "The interpolant is interpolated",
+            "I'm OK still",
+            "Success!",
+        ])
+        print lines
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/parser_stresstest.tmpl
+++ b/tools/tests/parser_stresstest.tmpl
@@ -8,7 +8,7 @@ $silly.sillysilly________silly['si' + 2 * r'l' + u'''y''':sillyfuncall(*args)].s
 #block foo_bar
 in a block
 #end block
-read past the directive, and into the "placeholder" before the $$i, I dare you!
+read past the directive, and into the "placeholder" before the \$i, I dare you!
 #for $i in $range(10)
 
 foo
@@ -50,7 +50,10 @@ inside a string literal this $ is untouched
 #                          **{'quuux': 'quuuux'})
 more literal text
 #end for
-less indented literal text with a literal $$ dollar sign
+less indented literal text with a literal $ dollar sign
+
+\#def this is not actually a def
+nor is this actually a \$placeholder
 
 yayayayay
 prepare for the KILLER

--- a/tools/tests/stress_test.py
+++ b/tools/tests/stress_test.py
@@ -44,6 +44,7 @@ class StressTest(EZIOTestCase):
         assert_in('#def notadef', self.result)
         assert_in("this isn't a $function", self.result)
         assert_in(r"one backslash looks like \ and two look like \\!", self.result)
+        assert_in("Two dollar signs make a $$", self.result)
         assert_in('#end def', self.result)
 
 if __name__ == '__main__':

--- a/tools/tests/stress_test.py
+++ b/tools/tests/stress_test.py
@@ -43,7 +43,7 @@ class StressTest(EZIOTestCase):
         assert_in('$bag.five', self.result)
         assert_in('#def notadef', self.result)
         assert_in("this isn't a $function", self.result)
-        assert_in(r"one backslash looks like \ or \ and two look like \\!", self.result)
+        assert_in(r"one backslash looks like \ and two look like \\!", self.result)
         assert_in('#end def', self.result)
 
 if __name__ == '__main__':

--- a/tools/tests/stress_test.py
+++ b/tools/tests/stress_test.py
@@ -39,6 +39,12 @@ class StressTest(EZIOTestCase):
 
     def test(self):
         super(StressTest, self).test()
+        # these should have been escaped as literal text:
+        assert_in('$bag.five', self.result)
+        assert_in('#def notadef', self.result)
+        assert_in("this isn't a $function", self.result)
+        assert_in(r"one backslash looks like \ or \ and two look like \\!", self.result)
+        assert_in('#end def', self.result)
 
 if __name__ == '__main__':
     testify.run()


### PR DESCRIPTION
I'm working on getting some of the production templates to compile. One issue I was encountering was one-line conditional statements, e.g.

```
<span id="my_span" #if config.addclass#class="the_span_class"#end if#>
```

and it was bugging me that we didn't support that. So this is an attempt to add that functionality.

I also changed escaping rules to conform to the Cheetah behavior. In particular:
1. $ and # can be escaped with \
2. \ is an escape if it precedes $ or #
3. $ does not require an escape if it's not followed by a letter, underscore, or [({ http://www.cheetahtemplate.org/docs/users_guide_html/users_guide.html#SECTION000620000000000000000
