### PR TITLE
Support a "wrapped" Python object "inside" the template object

### DIFF
--- a/ezio/Ezio.h
+++ b/ezio/Ezio.h
@@ -68,6 +68,23 @@ class PySmartPointer {
         }
 };
 
+namespace ezio_templates {
+
+    /** Base C++ class for all templates. */
+    class ezio_base_template {
+        public:
+            // display dictionary: namespace for dynamic template lookups
+            PyObject *display;
+            // a python list containing the pieces of the document being assembled
+            PyObject *transaction;
+            // if not NULL, a Python object that can be the target of dynamic references to `self`
+            PyObject *self_ptr;
+
+            ezio_base_template(PyObject *display, PyObject *transaction, PyObject *self_ptr) :
+                display(display), transaction(transaction), self_ptr(self_ptr) {}
+    };
+}
+
 /* Status codes that can be returned by the coercion/filtering code. */
 static const int COERCED_TO_STR = 0;
 static const int COERCED_TO_UNICODE = 1;

--- a/ezio/tmpl2py.py
+++ b/ezio/tmpl2py.py
@@ -105,7 +105,7 @@ def sanitize_dollars(string, munge_pair=IDENTITY_MUNGEPAIR):
             lines = string.split('\n')
 
             if lines[lineno][colno] != '$':
-                raise EzioNotDollarSignError()
+                raise EzioNotDollarSignError(lines[lineno][colno], lineno, colno)
 
             # delete the offending '$'
             lines[lineno] = lines[lineno][:colno] + lines[lineno][colno+1:]
@@ -374,9 +374,10 @@ class SetStrategy(object):
 
         if rest.startswith('global '):
             raise Exception('Set-global unsupported')
-        lvalue, _, rvalue = rest.partition(' ')
+        lvalue, _, rvalue = rest.partition('=')
         # generate an ordinary assignment statement
-        py_out.commit_line('%s = %s\n' % (sanitize_dollars(lvalue), sanitize_dollars(rvalue)))
+        py_out.commit_line('%s = %s\n' %
+                (sanitize_dollars(lvalue.strip()), sanitize_dollars(rvalue.strip())))
 
         driver.advance_past(driver.head)
 

--- a/tools/runtest
+++ b/tools/runtest
@@ -16,7 +16,7 @@ responder_name = "%s_respond" % testname
 responder = getattr(template_module, responder_name)
 
 start_time = time.time()
-result = responder(display)
+result = responder(display, None)
 elapsed = time.time() - start_time
 
 print result

--- a/tools/templates/self_pointer.tmpl
+++ b/tools/templates/self_pointer.tmpl
@@ -1,0 +1,13 @@
+#import os
+
+#def my_function()
+self.bar still $self.bar
+self.counter now $self.counter
+#end def
+
+self.bar $self.bar
+self.counter $self.counter
+## test calling native functions as attribute accesses on the `self` name:
+$self.my_function()
+
+asdf $asdf

--- a/tools/templates/set_statement.tmpl
+++ b/tools/templates/set_statement.tmpl
@@ -1,23 +1,23 @@
 #import os
 
 #def my_func()
-#set local_var bar
+#set local_var = bar
 my_func: $local_var
 #end def
 
-#set local_var quux
+#set local_var = quux
 respond: $local_var
 
 $my_func()
 
 ## exercise assignment statements that borrow a reference:
-#set local_var_2 os
-#set local_var_3 os.__file__
+#set local_var_2 = os
+#set local_var_3 = os.__file__
 os.__file__: $local_var_3
 again: $local_var_2.__file__
-#set local_var bat
+#set local_var = bat
 respond_reassignment: $local_var
 
 ## exercise assignment statements with nontrivial rvalues:
-#set local_var_in_pipes $add_pipes($local_var)
+#set local_var_in_pipes = $add_pipes($local_var)
 in_pipes: $local_var_in_pipes

--- a/tools/templates/set_statement_nameerror.tmpl
+++ b/tools/templates/set_statement_nameerror.tmpl
@@ -1,0 +1,10 @@
+#import os
+
+#set $local_var = $bar()
+local_var is $local_var
+
+#if False
+    #set local_var_2 = "asdf"
+#end if
+## this should raise a NameError
+local_var_2 is $local_var_2

--- a/tools/tests/call_exception.py
+++ b/tools/tests/call_exception.py
@@ -14,7 +14,9 @@ class ExceptionalObject(object):
     def raise_exception(self):
         raise AdHocException('this is an ad-hoc exception')
 
-display = {'bar': ExceptionalObject()}
+an_exceptional_object = ExceptionalObject()
+
+display = {'bar': an_exceptional_object}
 
 class TestCase(EZIOTestCase):
 
@@ -23,8 +25,11 @@ class TestCase(EZIOTestCase):
     def get_display(self):
         return display
 
+    def get_refcountables(self):
+        return [an_exceptional_object]
+
     def test(self):
-        assert_raises(AdHocException, self.run_templating)
+        self.perform_exception_test(AdHocException)
 
 if __name__ == '__main__':
     testify.run()

--- a/tools/tests/self_pointer.py
+++ b/tools/tests/self_pointer.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+
+import testify
+from testify.assertions import assert_equal, assert_in
+
+from tools.tests.test_case import EZIOTestCase
+
+BAR_VALUE = 'thisisthebarvaluefortheselfpointertest'
+
+class TestSelfPointer(object):
+
+    bar = BAR_VALUE
+
+    _counter = 0
+
+    @property
+    def counter(self):
+        result = self._counter
+        self._counter += 1
+        return result
+
+    def my_function(self):
+        """This should get masked by a native definition."""
+        return "unreachable"
+
+SELF_POINTER = TestSelfPointer()
+
+display = {'asdf': 'asdf'}
+
+class TestCase(EZIOTestCase):
+
+    target_template = 'self_pointer'
+
+    self_ptr = SELF_POINTER
+
+    num_stress_test_iterations = 0
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return [SELF_POINTER, BAR_VALUE]
+
+    def test(self):
+        super(TestCase, self).test()
+
+        lines = [line for line in self.result.split('\n') if line]
+        expected_lines = ['self.bar %s' % (BAR_VALUE,),
+                'self.counter 0',
+                'self.bar still %s' % (BAR_VALUE,),
+                'self.counter now 1',
+                'asdf asdf']
+        assert_equal(lines, expected_lines)
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/set_statement_nameerror.py
+++ b/tools/tests/set_statement_nameerror.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+
+import testify
+from testify.assertions import assert_equal, assert_in
+
+from tools.tests.test_case import EZIOTestCase
+
+BAR_VAL = 'thisisthereturnvalueofthebarfunction'
+def bar():
+    return BAR_VAL
+
+display = {
+    'bar': bar,
+}
+
+class TestCase(EZIOTestCase):
+
+    target_template = 'set_statement_nameerror'
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return [bar, BAR_VAL]
+
+    def test(self):
+        self.perform_exception_test(NameError)
+        assert_equal(self.exception.args[0], 'local_var_2')
+
+if __name__ == '__main__':
+    testify.run()


### PR DESCRIPTION
This is for compatibility with a "root template" setup --- where you have a base template that doesn't actually contain any template code, it's just a subclass of Cheetah.Template.Template, and then you call methods of it like so:

```
self.make_url("bar", $baz)
```

It's not an extremely interesting change. In theory the entire change is superfluous because we can just do

```
display['self'] = my_root_template
```

and then resolve `self` as a dynamic lookup in the display dict. I think it may be better to officially support this, though.
