### PR TITLE
Implement several missing language features

### DIFF
--- a/ezio/Ezio.h
+++ b/ezio/Ezio.h
@@ -47,6 +47,32 @@ static PyObject *resolve_path(PyObject *base, Py_ssize_t path_length, ...) {
     return base;
 }
 
+/** Helper for tuple unpacking; copy the internal buffer of a list or tuple
+  into a destination array, checking the size against `len`, and setting
+  appropriate exceptions on failure. Returns 0 on failure and 1 on success.
+  */
+static int sequence_copy(PyObject *seq, Py_ssize_t len, PyObject **dest) {
+    if (PyList_Check(seq)) {
+        if (PyList_GET_SIZE(seq) != len) {
+            PyErr_SetString(PyExc_ValueError, "Invalid sequence size");
+            return 0;
+        }
+        // copy the internal buffer
+        memcpy(dest, ((PyListObject *) seq)->ob_item, sizeof(PyObject *) * len);
+        return 1;
+    } else if (PyTuple_Check(seq)) {
+        if (PyTuple_GET_SIZE(seq) != len) {
+            PyErr_SetString(PyExc_ValueError, "Invalid sequence size");
+            return 0;
+        }
+        memcpy(dest, ((PyTupleObject *) seq)->ob_item, sizeof(PyObject *) * len);
+        return 1;
+    }
+
+    PyErr_SetString(PyExc_TypeError, "Cannot unpack non-list/tuple.");
+    return 0;
+}
+
 namespace ezio_templates {
 
     /** Base C++ class for all templates. */

--- a/ezio/compatibility.py
+++ b/ezio/compatibility.py
@@ -1,0 +1,24 @@
+"""
+Utilities to help with bidirectional Cheetah compatibility.
+"""
+
+def EZIO_skip(func):
+    """No-op decorator; tells EZIO to ignore a function definition.
+
+    Use this for code in a common template that you want to be visible to Cheetah,
+    but which EZIO should ignore at compile-time.
+
+    This only works if you decorate with exactly `EZIO_skip`; recommended use is
+    `from ezio.compatibility import EZIO_skip` and then `@EZIO_skip`.
+    """
+    return func
+
+def EZIO_noop(func):
+    """No-op decorator; tells EZIO to compile a function as empty.
+
+    Use this for code in a common template that you want to call from Cheetah,
+    but which EZIO should ignore at runtime.
+
+    See usage note for EZIO_skip.
+    """
+    return func

--- a/ezio/compiler.py
+++ b/ezio/compiler.py
@@ -1668,12 +1668,12 @@ class CodeGenerator(LineBufferMixin, NodeVisitor):
             self.add_line("else { Py_INCREF(%s); }" % (variable_target,))
 
         new_ref = new_ref_1 or new_ref_2
-        if variable_name is None:
-            if new_ref:
-                self.add_line("Py_DECREF(%s);" % (variable_target))
-                self.add_line("}")
-        else:
-            self.add_line("}")
+        if variable_name is None and (new_ref_1 or new_ref_2):
+            # dispose of the unneeded result
+            self.add_line("Py_DECREF(%s);" % (variable_target))
+        self.add_line("}")
+
+        if variable_target is not None:
             return new_ref
 
     def visit_Compare(self, compare_node, variable_name=None):

--- a/ezio/constants.py
+++ b/ezio/constants.py
@@ -19,7 +19,7 @@ BUILTIN_MODULE_NAME = '__builtin__'
 BUILTINS_WHITELIST = [
         'None', 'True', 'False', 'len', 'enumerate', 'range', 'xrange', 'list', 'tuple',
         'int', 'str', 'float', 'bool', 'dict', 'set', 'len', 'sum', 'min', 'max', 'any',
-        'all', 'sorted', 'print', 'repr', 'next', 'zip',
+        'all', 'sorted', 'print', 'repr', 'next', 'zip', 'map', 'reduce',
 ]
 
 class CompilerSettings(object):

--- a/ezio/constants.py
+++ b/ezio/constants.py
@@ -1,5 +1,5 @@
 """
-Magic words and numbers shared between compiler components.
+Magic words and numbers shared between compiler components; knobs and switches.
 """
 
 # magic marker used by tmpl2py when compiling #super (means "name of enclosing method")
@@ -8,3 +8,31 @@ CURRENT_METHOD_TAG = '__EZIO_current_method'
 # magic marker used by tmpl2py to tell py2moremeaningfulpy that the current function was
 # originally a #block, rather than a #def
 BLOCK_TAG = 'DIRECTIVE__block__'
+
+# builtin module (as in, the return value of `__import__('__builtin__')`)
+BUILTIN_MODULE_NAME = '__builtin__'
+
+# make all these built-in functions and objects available and statically resolvable
+# (because we resolve these names statically, we can't examine __builtin__ at runtime
+# and make all the names available --- and a lot of the builtins are things we actively
+# want to prevent people from using)
+BUILTINS_WHITELIST = [
+        'None', 'True', 'False', 'len', 'enumerate', 'range', 'xrange', 'list', 'tuple',
+        'int', 'str', 'float', 'bool', 'dict', 'set', 'len', 'sum', 'min', 'max', 'any',
+        'all', 'sorted', 'print', 'repr', 'next', 'zip',
+]
+
+class CompilerSettings(object):
+    """Holds all the switches and the knobs to control compilation."""
+
+    # enables use of the variadic path lookup method in Ezio.h,
+    # as opposed to the PathRegistry:
+    use_variadic_path_resolution = False
+
+    # this causes bare expression statements to be written to the
+    # templating transaction, and also enables special template
+    # semantics like dotted path lookup. The idea is that with this on,
+    # the compiler should compile the ASTs from py2moremeaningfulpy,
+    # and with it off, it should be a generalized Python AST compiler
+    # (although clearly most functionality is not implemented yet)
+    template_mode = True

--- a/ezio/constants.py
+++ b/ezio/constants.py
@@ -1,0 +1,10 @@
+"""
+Magic words and numbers shared between compiler components.
+"""
+
+# magic marker used by tmpl2py when compiling #super (means "name of enclosing method")
+CURRENT_METHOD_TAG = '__EZIO_current_method'
+
+# magic marker used by tmpl2py to tell py2moremeaningfulpy that the current function was
+# originally a #block, rather than a #def
+BLOCK_TAG = 'DIRECTIVE__block__'

--- a/tools/templates/boolean_operations.tmpl
+++ b/tools/templates/boolean_operations.tmpl
@@ -34,5 +34,11 @@ NO
 ##OK
 ###end if
 
+#if 1 or 2
+OK
+#else
+NO
+#end if
+
 $echo(0.0 or "OK")
 $echo("NO" and "OK")

--- a/tools/templates/builtins.tmpl
+++ b/tools/templates/builtins.tmpl
@@ -1,0 +1,5 @@
+#for i in range(10)# $i#end for#
+
+#for i, x in enumerate(seq)
+$i $x
+#end for

--- a/tools/templates/compatibility.tmpl
+++ b/tools/templates/compatibility.tmpl
@@ -1,0 +1,25 @@
+#from ezio.compatibility import EZIO_skip
+#from ezio.compatibility import EZIO_noop
+
+## this should get skipped in compilation,
+## and `$first` should get looked up in the display dict
+#@EZIO_skip
+#def first()
+unreachable
+#end def
+
+## this should get blanked during compilation,
+## so it shouldn't print "unreachable" but it should still mask $second from a display lookup
+#@EZIO_noop
+#def second()
+unreachable
+#end def
+
+## This is a normal function definition
+#def third()
+third
+#end def
+
+$first()
+$second()
+$third()

--- a/tools/templates/imports.tmpl
+++ b/tools/templates/imports.tmpl
@@ -1,35 +1,22 @@
-#import sys, os, email
-#import sys.os.email
+#import sys, os
 #import os as so
 #from os import path
-#from email import util, errors
+#from email import utils, errors
+#from email.mime import image
+#import email.mime.image
 #import bisect
+#from email import charset as goat
+#from xml.dom import minidom as sheep
 
-
-#def ezio()
-<html><head><title>ezio</title></head>
-<body>
-<p>Here is a string literal</p>
-<p>And the file for email is: $email.__file__</p>
-<p>And the name of this module is: $bisect.__name__</p>
-<table>
-#for $bag in $bags
-<tr>
-    <td>stuff</td><td>$bag.one</td>
-    <td>stuff</td><td>$bag.two</td>
-    <td>stuff</td><td>$bag.three</td>
-    <td>stuff</td><td>$bag.four</td>
-    <td>stuff</td><td>$bag.five</td>
-    <td>stuff</td><td>$bag.six</td>
-    <td>stuff</td><td>$bag.seven</td>
-    <td>stuff</td><td>$bag.eight</td>
-    <td>stuff</td><td>$bag.nine</td>
-    <td>stuff</td><td>$bag.ten</td>
-</tr>
-#end for
-</table>
-</body></html>
-#end def
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"  "http://www.w3.org/TR/html4/loose.dtd">
-$ezio()
+## just test that we imported the right things from the right places
+$bisect.__file__
+$so.__file__
+$os.__file__
+$path.__file__
+$utils.__file__
+$errors.__file__
+$image.__file__
+$email.mime.image.__file__
+$email.__file__
+$goat.__file__
+$sheep.__file__

--- a/tools/templates/misc_features.tmpl
+++ b/tools/templates/misc_features.tmpl
@@ -1,0 +1,38 @@
+## tuples
+#set my_created_tuple = (1, 2, 3, 4, 5)
+#for arg in my_created_tuple
+$arg
+#end for
+
+## lists
+#set my_created_list = [6, 7, 8, 9, 10]
+#for arg in my_created_list
+$arg
+#end for
+
+## tuples, mixing it up a little
+#set mytuple = (11, "twelve", 13, get_fourteen(), 15)
+#for arg in mytuple
+$arg
+#end for
+
+## if-expression (ternary operator)
+$("OK" if True else "NO")
+$($ok if True else $no)
+#for arg in ($oks if ($false_obj or $true_obj) else $nos)
+$arg
+#end for
+
+## subscripting
+$mydict["a"]
+$mydict[$mykey]
+$mylist[0]
+$mylist[$myindex]
+
+## unary operations
+$("OK" if -one == -1 else "NO")
+
+## binary operations
+$("OK" if 1 + 1 == 2 else "NO")
+## (this should be an integer division)
+$("NO" if 3/2 == 1.5 else "OK")

--- a/tools/templates/misc_features.tmpl
+++ b/tools/templates/misc_features.tmpl
@@ -36,3 +36,7 @@ $("OK" if -one == -1 else "NO")
 $("OK" if 1 + 1 == 2 else "NO")
 ## (this should be an integer division)
 $("NO" if 3/2 == 1.5 else "OK")
+
+#set thedict = {1: 2, 'a': 'b', 'asdf': $ok}
+$("OK" if thedict['a'] == 'b' else "NO")
+$thedict['asdf']

--- a/tools/templates/set_statement.tmpl
+++ b/tools/templates/set_statement.tmpl
@@ -5,6 +5,14 @@
 my_func: $local_var
 #end def
 
+## test reassignment to a function argument
+#def my_other_func(arg=None)
+#if arg is None
+#set arg = $get_default_str()
+#end if
+$arg
+#end def
+
 #set local_var = quux
 respond: $local_var
 
@@ -21,3 +29,6 @@ respond_reassignment: $local_var
 ## exercise assignment statements with nontrivial rvalues:
 #set local_var_in_pipes = $add_pipes($local_var)
 in_pipes: $local_var_in_pipes
+
+$my_other_func()
+$my_other_func("this is the second call to my_func")

--- a/tools/templates/super_keyword/simple_subclass.tmpl
+++ b/tools/templates/super_keyword/simple_subclass.tmpl
@@ -1,0 +1,10 @@
+#extends simple_superclass
+
+#def first()
+simple_subclass::first
+#end def
+
+#def second()
+simple_subclass::second
+#super()
+#end def

--- a/tools/templates/super_keyword/simple_superclass.tmpl
+++ b/tools/templates/super_keyword/simple_superclass.tmpl
@@ -1,0 +1,10 @@
+#def first()
+simple_superclass::first
+#end def
+
+#def second()
+simple_superclass::second
+#end def
+
+$first()
+$second()

--- a/tools/templates/tuple_unpacking.tmpl
+++ b/tools/templates/tuple_unpacking.tmpl
@@ -1,0 +1,26 @@
+#import os
+
+begin first test
+#for a, b in first_sequence
+$a $b
+#end for
+end first test
+
+begin second test
+#for w, (x, y), z in second_sequence
+$x $z
+#end for
+end second test
+
+begin third test
+#set bar = $get_bar_value
+$bar
+#for bar, baz in third_sequence
+$bar $baz
+#end for
+end third test
+
+begin fourth test
+#set u, v = fourth_sequence
+$u $v
+end fourth test

--- a/tools/tests/boolean_operations.py
+++ b/tools/tests/boolean_operations.py
@@ -51,7 +51,7 @@ class TestCase(EZIOTestCase):
     def test(self):
         super(TestCase, self).test()
 
-        assert_equal(self.result.split(), ['OK'] * 7)
+        assert_equal(self.result.split(), ['OK'] * 8)
         # test that the truth values were accessed only as many times as necessary:
         assert_equal(display['c'].access_count, 0)
         assert_equal(display['d'].access_count, 1)

--- a/tools/tests/builtins.py
+++ b/tools/tests/builtins.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+
+import testify
+from testify.assertions import assert_equal, assert_in
+
+from tools.tests.test_case import EZIOTestCase
+
+seq = ['a', 'b', 'c']
+
+display = {
+        'seq': seq,
+}
+
+class TestCase(EZIOTestCase):
+
+    target_template = 'builtins'
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return [seq]
+
+    def test(self):
+        super(TestCase, self).test()
+
+        expected_lines = [
+                ''.join(' %d' % (num,) for num in xrange(10)),
+                '0 a',
+                '1 b',
+                '2 c',
+        ]
+
+        assert_equal(self.lines, expected_lines)
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/call_statement.py
+++ b/tools/tests/call_statement.py
@@ -32,9 +32,7 @@ class TestCase(EZIOTestCase):
     def test(self):
         super(TestCase, self).test()
 
-        # split by newline, ignoring blank lines:
-        split_result = [line for line in self.result.split('\n') if line]
-        assert_equal(split_result,
+        assert_equal(self.lines,
                 ['<div>', 'hi from baltimore', '</div>',
                  '<p>', "to king's landing!", '</p>'])
 

--- a/tools/tests/coercion.py
+++ b/tools/tests/coercion.py
@@ -36,7 +36,7 @@ class SimpleTestCase(EZIOTestCase):
     def test(self):
         super(SimpleTestCase, self).test()
         assert_equal(
-            self.result.strip().split('\n'),
+            self.lines,
             ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohai',
              'fifth', 'hommage à jack'
             ]

--- a/tools/tests/compatibility.py
+++ b/tools/tests/compatibility.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import sys
+
+import testify
+from testify.assertions import assert_equal
+
+from tools.tests.test_case import EZIOTestCase
+
+def first():
+    return "first"
+
+def second():
+    return "unreachable"
+
+def third():
+    return "unreachable"
+
+display = { 'first': first, 'second': second, 'third': third }
+
+class TestCase(EZIOTestCase):
+
+    target_template = 'compatibility'
+
+    def get_display(self):
+        return display
+
+    def test(self):
+        super(TestCase, self).test()
+        assert_equal(self.lines, ['first', 'third'])
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/imports.py
+++ b/tools/tests/imports.py
@@ -1,6 +1,9 @@
 #/usr/bin/python
 
+import sys
+
 import testify
+from testify.assertions import assert_equal
 
 from tools.tests.test_case import EZIOTestCase
 
@@ -24,7 +27,12 @@ class TestCase(EZIOTestCase):
 
     def test(self):
         super(TestCase, self).test()
-        assert 'And the name of this module is: bisect' in self.result
+
+        modules = ['bisect', 'os', 'os', 'os.path', 'email.utils', 'email.errors',
+                'email.mime.image', 'email.mime.image', 'email', 'email.charset',
+                'xml.dom.minidom']
+        files = [sys.modules[module].__file__ for module in modules]
+        assert_equal(self.lines, files)
 
 if __name__ == '__main__':
     testify.run()

--- a/tools/tests/misc_features.py
+++ b/tools/tests/misc_features.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import sys
+
+import testify
+from testify.assertions import assert_equal
+
+from tools.tests.test_case import EZIOTestCase
+
+fourteen = "fourteen"
+def get_fourteen():
+    return fourteen
+
+true_obj = [1, 2, 3]
+false_obj = set()
+oks = ['OK']
+nos = ['NO']
+
+mykey = (1, 2, 3, 4, 5)
+mylist = ['OK', 'OK']
+mydict = { 'a': 'OK', mykey: 'OK' }
+
+display = {
+        'get_fourteen': get_fourteen,
+        'true_obj': true_obj,
+        'false_obj': false_obj,
+        'ok': 'OK',
+        'no': 'NO',
+        'oks': oks,
+        'nos': nos,
+        'mykey': mykey,
+        'mydict': mydict,
+        'mylist': mylist,
+        'myindex': 1,
+        'one': 1,
+}
+
+class TestCase(EZIOTestCase):
+
+    target_template = 'misc_features'
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        return [fourteen, true_obj, false_obj, oks, nos] + oks + nos + [mykey, mydict, mylist]
+
+    def test(self):
+        super(TestCase, self).test()
+        expected_result = ([str(n) for n in xrange(1, 11)] +
+                ['11', 'twelve', '13', 'fourteen', '15'] + ['OK'] * 10)
+        assert_equal(self.lines, expected_result)
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/misc_features.py
+++ b/tools/tests/misc_features.py
@@ -49,7 +49,7 @@ class TestCase(EZIOTestCase):
     def test(self):
         super(TestCase, self).test()
         expected_result = ([str(n) for n in xrange(1, 11)] +
-                ['11', 'twelve', '13', 'fourteen', '15'] + ['OK'] * 10)
+                ['11', 'twelve', '13', 'fourteen', '15'] + ['OK'] * 12)
         assert_equal(self.lines, expected_result)
 
 if __name__ == '__main__':

--- a/tools/tests/oneline_conditionals.py
+++ b/tools/tests/oneline_conditionals.py
@@ -32,8 +32,7 @@ class TestCase(EZIOTestCase):
     def test(self):
         super(TestCase, self).test()
 
-        lines = [line for line in self.result.split('\n') if line]
-        assert_equal(lines, [
+        assert_equal(self.lines, [
             "I'm OK",
             "I'm OK",
             "The alphabet begins with a b c d e",
@@ -41,7 +40,6 @@ class TestCase(EZIOTestCase):
             "I'm OK still",
             "Success!",
         ])
-        print lines
 
 if __name__ == '__main__':
     testify.run()

--- a/tools/tests/self_pointer.py
+++ b/tools/tests/self_pointer.py
@@ -47,13 +47,12 @@ class TestCase(EZIOTestCase):
     def test(self):
         super(TestCase, self).test()
 
-        lines = [line for line in self.result.split('\n') if line]
         expected_lines = ['self.bar %s' % (BAR_VALUE,),
                 'self.counter 0',
                 'self.bar still %s' % (BAR_VALUE,),
                 'self.counter now 1',
                 'asdf asdf']
-        assert_equal(lines, expected_lines)
+        assert_equal(self.lines, expected_lines)
 
 if __name__ == '__main__':
     testify.run()

--- a/tools/tests/set_statement.py
+++ b/tools/tests/set_statement.py
@@ -45,6 +45,7 @@ class TestCase(EZIOTestCase):
                 DEFAULT_ARGUMENT,
                 'this is the second call to my_func',
         ]
+        assert_equal(self.lines, expected_lines)
 
 if __name__ == '__main__':
     testify.run()

--- a/tools/tests/set_statement.py
+++ b/tools/tests/set_statement.py
@@ -11,11 +11,15 @@ from tools.tests.test_case import EZIOTestCase
 def add_pipes(my_string):
     return "|%s|" % (my_string,)
 
+DEFAULT_ARGUMENT = 'this is the first call to my_func'
+def get_default_str(): return DEFAULT_ARGUMENT
+
 display = {
     'add_pipes': add_pipes,
     'bar': 'bar',
     'bat': 'bat',
     'quux': 'quux',
+    'get_default_str': get_default_str,
 }
 
 class TestCase(EZIOTestCase):
@@ -26,17 +30,21 @@ class TestCase(EZIOTestCase):
         return display
 
     def get_refcountables(self):
-        return sorted(display.itervalues()) + [os, os.__file__]
+        return sorted(display.itervalues()) + [os, os.__file__, DEFAULT_ARGUMENT, get_default_str]
 
     def test(self):
         super(TestCase, self).test()
 
-        assert_in('my_func: bar', self.result)
-        assert_in('respond: quux', self.result)
-        assert_in('os.__file__: %s' % (os.__file__,), self.result)
-        assert_in('again: %s' % (os.__file__,), self.result)
-        assert_in('respond_reassignment: bat', self.result)
-        assert_in('in_pipes: |bat|', self.result)
+        expected_lines = [
+                'respond: quux',
+                'my_func: bar',
+                'os.__file__: %s' % (os.__file__,),
+                'again: %s' % (os.__file__,),
+                'respond_reassignment: bat',
+                'in_pipes: |bat|',
+                DEFAULT_ARGUMENT,
+                'this is the second call to my_func',
+        ]
 
 if __name__ == '__main__':
     testify.run()

--- a/tools/tests/super_keyword.py
+++ b/tools/tests/super_keyword.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+
+import testify
+from testify.assertions import assert_equal
+
+from tools.tests.test_case import EZIOTestCase
+
+display = {}
+
+class SuperclassTestCase(EZIOTestCase):
+    project_name = 'super_keyword'
+    target_template = 'simple_superclass'
+
+    def get_display(self):
+        return display
+
+    def test(self):
+        super(SuperclassTestCase, self).test()
+        # experimental control:
+        assert_equal(self.lines, ['simple_superclass::first', 'simple_superclass::second'])
+
+class SubclassTestCase(EZIOTestCase):
+    project_name = 'super_keyword'
+    target_template = 'simple_subclass'
+
+    def get_display(self):
+        return display
+
+    def test(self):
+        super(SubclassTestCase, self).test()
+
+        assert_equal(self.lines,
+                ['simple_subclass::first',
+                 'simple_subclass::second',
+                 # test that we dispatched correctly to the superclass method
+                 'simple_superclass::second',
+                ])
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/test_case.py
+++ b/tools/tests/test_case.py
@@ -116,6 +116,7 @@ class EZIOTestCase(testify.TestCase):
             assert_equal(self.result, self.expected_result)
             assert_equal(self.get_reference_counts(), self.expected_reference_counts)
 
+        self.lines = [line for line in self.result.split('\n') if line]
 
     def perform_exception_test(self, exc_class):
         self.expected_reference_counts = self.get_reference_counts()

--- a/tools/tests/tuple_unpacking.py
+++ b/tools/tests/tuple_unpacking.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+
+import testify
+from testify.assertions import assert_equal, assert_in
+
+from tools.tests.test_case import EZIOTestCase
+
+first_sequence = [('a', 'b'), ('c', 'd')]
+second_sequence = [('w', ('x', 'y'), 'z'), ('a', ('b', 'c'), 'd')]
+bar = 'thisisthebarvalue'
+third_sequence = [('i', 'j'), ('k', 'l')]
+fourth_sequence = ['u', 'v']
+
+def flatten_helper(sequence, flattened_sequence):
+    for item in sequence:
+        if isinstance(item, list) or isinstance(item, tuple):
+            flatten_helper(item, flattened_sequence)
+        flattened_sequence.append(item)
+
+def flatten(sequence):
+    """Recursively create a list of all hereditary members of `sequence`."""
+    result = [sequence]
+    flatten_helper(sequence, result)
+    return result
+
+display = {
+    'first_sequence': first_sequence,
+    'second_sequence': second_sequence,
+    'get_bar_value': bar,
+    'third_sequence': third_sequence,
+    'fourth_sequence': fourth_sequence,
+}
+
+class TestCase(EZIOTestCase):
+
+    target_template = 'tuple_unpacking'
+
+    def get_display(self):
+        return display
+
+    def get_refcountables(self):
+        refcountables = [bar]
+        for sequence in display.values():
+            refcountables.extend(flatten(sequence))
+        return refcountables
+
+    def test(self):
+        super(TestCase, self).test()
+
+        expected_lines = [
+                'begin first test',
+                'a b',
+                'c d',
+                'end first test',
+                'begin second test',
+                'x z',
+                'b d',
+                'end second test',
+                'begin third test',
+                bar,
+                'i j',
+                'k l',
+                'end third test',
+                'begin fourth test',
+                'u v',
+                'end fourth test',
+        ]
+
+        assert_equal(self.lines, expected_lines)
+
+if __name__ == '__main__':
+    testify.run()

--- a/tools/tests/unicode_coercion.py
+++ b/tools/tests/unicode_coercion.py
@@ -44,7 +44,7 @@ class SimpleTestCase(EZIOTestCase):
         # note that 'asdf' == u'asdf', so we don't need to explicitly prefix the
         # literals here with u:
         assert_equal(
-            self.result.strip().split('\n'),
+            self.lines,
             ['first', '1', 'second', '2.0', 'third', 'asdf', 'fourth', 'ohaiunicode',
              'fifth', u'hommage \xe0 jack'
             ]


### PR DESCRIPTION
This should cover a lot of the stuff I observed when trying to compile the production templates.
- Lists, tuples, subscript operations, unary and binary arithmetic
- Reassignment of function arguments (by optionally promoting them to owned references)
- The #super directive for calling superclass methods
- Fully general import statements
- EZIO_skip and EZIO_noop, decorators for marking EZIO-incompatible Cheetah code
- Tuple unpacking
- Built-in names (`enumerate`, `range`, etc.)
